### PR TITLE
remove None so the dict in markers.py can be sorted

### DIFF
--- a/vispy/visuals/line_plot.py
+++ b/vispy/visuals/line_plot.py
@@ -56,7 +56,7 @@ class LinePlotVisual(CompoundVisual):
                       'marker_size', 'symbol')
     _kw_trans = dict(marker_size='size')
 
-    def __init__(self, data, color='k', symbol=None, line_kind='-',
+    def __init__(self, data, color='k', symbol='None', line_kind='-',
                  width=1., marker_size=10., edge_color='k', face_color='w',
                  edge_width=1., connect='strip'):
         if line_kind != '-':

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -474,6 +474,7 @@ _marker_dict = {
     '^': triangle_up,
     'v': triangle_down,
     '*': star,
+    'None': None,
 }
 marker_types = tuple(sorted(list(_marker_dict.keys())))
 
@@ -573,7 +574,7 @@ class MarkersVisual(Visual):
             The symbol.
         """
         _check_valid('symbol', symbol, marker_types)
-        if symbol is None:
+        if symbol is 'None':
             self._marker_fun = None
         else:
             self._marker_fun = Function(_marker_dict[symbol])

--- a/vispy/visuals/markers.py
+++ b/vispy/visuals/markers.py
@@ -474,7 +474,6 @@ _marker_dict = {
     '^': triangle_up,
     'v': triangle_down,
     '*': star,
-    None: None,
 }
 marker_types = tuple(sorted(list(_marker_dict.keys())))
 


### PR DESCRIPTION
Here is the traceback before the change:
```
Traceback (most recent call last):
  File "examples/basics/visuals/markers.py", line 12, in <module>
    from vispy import app, gloo, visuals
  File "/home/bollu/prog/vispy/vispy/visuals/__init__.py", line 25, in <module>
    from .line_plot import LinePlotVisual  # noqa
  File "/home/bollu/prog/vispy/vispy/visuals/line_plot.py", line 8, in <module>
    from .markers import MarkersVisual
  File "/home/bollu/prog/vispy/vispy/visuals/markers.py", line 479, in <module>
    marker_types = tuple(sorted(list(_marker_dict.keys())))
TypeError: unorderable types: NoneType() < str()

```

Here is image after:

![screenshot from 2015-06-22 02-41-40](https://cloud.githubusercontent.com/assets/1694861/8273377/6f4983d2-1888-11e5-8eb2-c4bda72e3739.png)
