### PR TITLE
Ticker

### DIFF
--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -221,17 +221,12 @@ class Ticker(object):
             scale = domain[1] - domain[0]
 
             tr_sys = self.axis.transforms
-            visual_to_document = tr_sys.get_transform('visual', 'document')
-            length = np.array([self.axis.bounds(0), self.axis.bounds(1)]).T
-            length = visual_to_document.map(length)  # pixels
-            length = length[1] - length[0]
-            # XXX for some reason this doesn't update when resizing, bug with
-            # the transform system?
-            # n_inches = np.sqrt(np.sum(length ** 2)) / tr_sys.dpi
+            length = self.axis.pos[1] - self.axis.pos[0]  # in logical coords
+            n_inches = np.sqrt(np.sum(length ** 2)) / tr_sys.dpi
 
             # major = np.linspace(domain[0], domain[1], num=11)
-            major = MaxNLocator(10).tick_values(*domain)
-            # major = _get_ticks_talbot(domain[0], domain[1], n_inches)
+            # major = MaxNLocator(10).tick_values(*domain)
+            major = _get_ticks_talbot(domain[0], domain[1], n_inches, 2)
 
             labels = ['%g' % x for x in major]
             majstep = major[1] - major[0]

--- a/vispy/visuals/axis.py
+++ b/vispy/visuals/axis.py
@@ -227,11 +227,11 @@ class Ticker(object):
             length = length[1] - length[0]
             # XXX for some reason this doesn't update when resizing, bug with
             # the transform system?
-            n_inches = np.sqrt(np.sum(length ** 2)) / tr_sys.dpi
+            # n_inches = np.sqrt(np.sum(length ** 2)) / tr_sys.dpi
 
             # major = np.linspace(domain[0], domain[1], num=11)
-            # major = MaxNLocator(10).tick_values(*domain)
-            major = _get_ticks_talbot(domain[0], domain[1], n_inches)
+            major = MaxNLocator(10).tick_values(*domain)
+            # major = _get_ticks_talbot(domain[0], domain[1], n_inches)
 
             labels = ['%g' % x for x in major]
             majstep = major[1] - major[0]


### PR DESCRIPTION
Good to go from my end. You can choose between a dumb one `linspace`, matplotlib's algorithm, and [Talbot's algorithm] (http://www.justintalbot.com/research/axis-labeling/comment-page-1/#comment-90585) by uncommenting lines. At some point we should make the API for this easy. I know you told me to subclass `Ticker`, but I think we might want to make it simpler. Users could provide a function that takes `(vmin, vmax)` and returns the ticks, as shown by the fact that you can just uncomment any of those three lines and be good to go. We should figure that out after scipy, though -- for now this should get you going.

I did notice a couple of odd behaviors.

1. The `n_inches` I compute above does not change when I resize my window. I must be using the transform system wrong, or the transform system is broken, but I assumed going from visual coords to document coords would get me the number of logical pixels, which I could then map using DPI into inches.

2. When I resize the window horizontally, the labeling on the axis changes even though the data does not. So there is some bug in the linking.

Any ideas about those?