### PR TITLE
per-fragment phong shading for mesh visual

### DIFF
--- a/examples/basics/visuals/mesh.py
+++ b/examples/basics/visuals/mesh.py
@@ -64,9 +64,10 @@ class Canvas(app.Canvas):
             x = 800. * (i % grid[0]) / grid[0] + 400. / grid[0] - 2
             y = 800. * (i // grid[1]) / grid[1] + 400. / grid[1] + 2
             transform = ChainTransform([STTransform(translate=(x, y),
-                                                    scale=(s, s, 1)),
+                                                    scale=(s, s, s)),
                                         self.rotation])
             mesh.transform = transform
+            mesh.transforms.scene_transform = STTransform(scale=(1, 1, 0.01))
 
         self.show()
 

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -80,26 +80,27 @@ void main() {
     //DIFFUSE
     float diffusek = dot(v_light_vec, v_normal_vec);
     //clamp, because 0 < theta < pi/2
-    diffusek = (diffusek < 0. ? 0. : diffusek);
+    diffusek  = clamp(diffusek, 0, 1);
     vec4 diffuse_color = v_light_color * diffusek;
     //diffuse_color.a = 1.0;
 
     //SPECULAR
-    //if light and normal are obtuse, no specular highlight
-    float speculark = dot(v_normal_vec, v_light_vec) < 0.0 ? 0 : 1;
     //reflect light wrt normal for the reflected ray, then
     //find the angle made with the eye
-    speculark = speculark * dot(reflect(v_light_vec, v_normal_vec), v_eye_vec);
-    speculark = (speculark < 0. ? 0. : speculark);
+    float speculark = dot(reflect(v_light_vec, v_normal_vec), v_eye_vec);
+    speculark = clamp(speculark, 0, 1);
     //raise to the material's shininess, multiply with a
     //small factor for spread
-    speculark = 10 * pow(speculark, 200.0);
+    speculark = 20 * pow(speculark, 200.0);
 
     vec4 specular_color = v_light_color * speculark;
 
 
     gl_FragColor =
-        v_base_color * (v_ambientk + diffuse_color) + specular_color;
+       v_base_color * (v_ambientk + diffuse_color) + specular_color;
+
+    //gl_FragColor = vec4(speculark, 0, 1, 1.0);
+
 
 }
 """
@@ -352,7 +353,7 @@ class MeshVisual(Visual):
             self.shared_program.vert['base_color'] = colors
 
             # Additional phong properties
-            self.shared_program.vert['light_dir'] = (-1.0, -10.0, 0)
+            self.shared_program.vert['light_dir'] = (10, 5, -5)
             self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
             self.shared_program.vert['ambientk'] = (0.3, 0.3, 0.3, 1.0)
 

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -97,6 +97,7 @@ void main() {
 
     gl_FragColor =
         v_base_color * (v_ambientk + diffuse_color) + specular_color;
+
 }
 """
 
@@ -368,7 +369,7 @@ class MeshVisual(Visual):
             self.shared_program.vert['base_color'] = colors
 
             # Additional phong properties
-            self.shared_program.vert['light_dir'] = (1.0, 1.0, -1.0)
+            self.shared_program.vert['light_dir'] = (1.0, -10.0, -5.0)
             self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
             self.shared_program.vert['ambientk'] = (0.3, 0.3, 0.3, 1.0)
 

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -179,14 +179,8 @@ class MeshVisual(Visual):
         self._colors = VertexBuffer(np.zeros((0, 4), dtype=np.float32))
         self._normals = VertexBuffer(np.zeros((0, 3), dtype=np.float32))
 
-        # Whether to use _faces index
-        self._indexed = None
-
         # Uniform color
         self._color = Color(color)
-
-        # primitive mode
-        self._draw_mode = mode
 
         # varyings
         self._color_var = Varying('v_color', dtype='vec4')
@@ -200,6 +194,9 @@ class MeshVisual(Visual):
                             vertex_colors=vertex_colors,
                             face_colors=face_colors, meshdata=meshdata,
                             color=color)
+        
+        # primitive mode
+        self._draw_mode = mode
 
     def set_data(self, vertices=None, faces=None, vertex_colors=None,
                  face_colors=None, color=None, meshdata=None):
@@ -287,7 +284,7 @@ class MeshVisual(Visual):
             self._vertices.set_data(v, convert=True)
             self._normals.set_data(md.get_vertex_normals(), convert=True)
             self._faces.set_data(md.get_faces(), convert=True)
-            self._indexed = True
+            self._index_buffer = self._faces
             if md.has_vertex_color():
                 self._colors.set_data(md.get_vertex_colors(), convert=True)
             elif md.has_face_color():
@@ -309,7 +306,7 @@ class MeshVisual(Visual):
                 self._normals.set_data(normals, convert=True)
             else:
                 self._normals.set_data(np.zeros((0, 3), dtype=np.float32))
-            self._indexed = False
+            self._index_buffer = None
             if md.has_vertex_color():
                 self._colors.set_data(md.get_vertex_colors(indexed='faces'),
                                       convert=True)

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -17,6 +17,7 @@ from ..gloo import VertexBuffer, IndexBuffer
 from ..geometry import MeshData
 from ..color import Color
 
+# Shaders for lit rendering (using phong shading)
 shading_vertex_template = """
 varying vec3 v_normal_vec;
 varying vec3 v_light_vec;
@@ -74,12 +75,14 @@ varying vec4 v_light_color;
 varying vec4 v_base_color;
 
 void main() {
+
+
     //DIFFUSE
     float diffusek = dot(v_light_vec, v_normal_vec);
     //clamp, because 0 < theta < pi/2
     diffusek = (diffusek < 0. ? 0. : diffusek);
     vec4 diffuse_color = v_light_color * diffusek;
-    diffuse_color.a = 1.0;
+    //diffuse_color.a = 1.0;
 
     //SPECULAR
     //if light and normal are obtuse, no specular highlight
@@ -101,8 +104,7 @@ void main() {
 }
 """
 
-# -------------------------------
-# OLD CODE-------------------------------
+# Shader code for non lighted rendering
 vertex_template = """
 void main() {
     gl_Position = $transform($to_vec4($position));
@@ -115,25 +117,6 @@ void main() {
 }
 """
 
-
-phong_template = """
-vec4 phong_shading(vec4 color) {
-    vec4 o = $transform(vec4(0, 0, 0, 1));
-    vec4 n = $transform(vec4($normal, 1));
-    vec3 norm = normalize((n-o).xyz);
-    vec3 light = normalize($light_dir.xyz);
-    float p = dot(light, norm);
-    p = (p < 0. ? 0. : p);
-    vec4 diffuse = $light_color * p;
-    diffuse.a = 1.0;
-    p = dot(reflect(light, norm), vec3(0,0,1));
-    if (p < 0.0) {
-        p = 0.0;
-    }
-    vec4 specular = $light_color * 5.0 * pow(p, 100.);
-    return color * ($ambient + diffuse) + specular;
-}
-"""
 
 # Functions that can be used as is (don't have template variables)
 # Consider these stored in a central location in vispy ...
@@ -369,7 +352,7 @@ class MeshVisual(Visual):
             self.shared_program.vert['base_color'] = colors
 
             # Additional phong properties
-            self.shared_program.vert['light_dir'] = (1.0, -10.0, -5.0)
+            self.shared_program.vert['light_dir'] = (-1.0, -10.0, 0)
             self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
             self.shared_program.vert['ambientk'] = (0.3, 0.3, 0.3, 1.0)
 

--- a/vispy/visuals/mesh.py
+++ b/vispy/visuals/mesh.py
@@ -64,7 +64,7 @@ void main() {
 
     vec4 specular_color = $light_color * speculark;
 
-    v_color = $base_color * $ambientk + diffuse_color + specular_color;
+    v_color = $base_color * ($ambientk + diffuse_color) + specular_color;
     gl_Position = $transform($to_vec4($position));
 }
 """
@@ -344,7 +344,7 @@ class MeshVisual(Visual):
             self.shared_program.vert['normal'] = normals;
 
             # Additional phong properties
-            self.shared_program.vert['light_dir'] = (1.0, 1.0, 5.0)
+            self.shared_program.vert['light_dir'] = (1.0, 1.0, -1.0)
             self.shared_program.vert['light_color'] = (1.0, 1.0, 1.0, 1.0)
             self.shared_program.vert['ambientk'] = (0.3, 0.3, 0.3, 1.0)
             self.shared_program.vert['base_color'] = colors


### PR DESCRIPTION
Screenshot:

![screenshot from 2015-06-29 01-55-50](https://cloud.githubusercontent.com/assets/1694861/8398160/06644f44-1e02-11e5-9dec-52e6344dc929.png)


Are these needed? 

- [ ] use blinn-phong for optimization?
- [ ] pass varying by using vispy's `Varying` class directly to the fragment shader