### PR TITLE
FIX: Fix examples

### DIFF
--- a/examples/basics/scene/stereo.py
+++ b/examples/basics/scene/stereo.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# vispy: testskip
 # -----------------------------------------------------------------------------
 # Copyright (c) 2015, Vispy Development Team. All Rights Reserved.
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
@@ -8,6 +9,8 @@
 Example demonstrating stereo vision in a scene has an anisotropic aspect
 ratio. This example can be used to test that the cameras behave
 correctly with nested translated/rotated cameras.
+
+NOTE: This example is currently broken!
 """
 
 import numpy as np

--- a/examples/basics/visuals/custom_visual.py
+++ b/examples/basics/visuals/custom_visual.py
@@ -76,6 +76,9 @@ class MarkerVisual(Visual):
                           blend_func=('src_alpha', 'one_minus_src_alpha'))
         self._draw_mode = 'points'
 
+    def _prepare_transforms(self, view=None):
+        view.view_program.vert['transform'] = view.transforms.get_transform()
+
     def _prepare_draw(self, view):
         # attributes / uniforms are not available until program is built
         self.shared_program['a_position'] = VertexBuffer(self._pos)

--- a/examples/demo/plot/plot.py
+++ b/examples/demo/plot/plot.py
@@ -10,7 +10,7 @@ import numpy as np
 from vispy import plot as vp
 from vispy.io import load_data_file
 
-data = np.load(load_data_file('electrophys/iv_curve.npz'))
+data = np.load(load_data_file('electrophys/iv_curve.npz'))['arr_0']
 time = np.arange(0, data.shape[1], 1e-4)
 
 fig = vp.Fig(size=(800, 800), show=False)

--- a/examples/demo/scene/flow_lines.py
+++ b/examples/demo/scene/flow_lines.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015, Vispy Development Team. All Rights Reserved.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+
+"""
+Show vector field flow
+"""
+
 from __future__ import division
 
 from vispy import app, scene, visuals, gloo
@@ -167,19 +177,18 @@ color[..., :2] = (field + 5) / 10.
 color[..., 2] = 0.5
 color[..., 3] = 0.5
 
-win = scene.SceneCanvas(keys='interactive', show=True)
-view = win.central_widget.add_view(camera='panzoom')
-#img = scene.Image(field, parent=view.scene)
+canvas = scene.SceneCanvas(keys='interactive', show=True)
+view = canvas.central_widget.add_view(camera='panzoom')
 
 vfield = VectorField(field[..., :2], spacing=0.5, segments=30, seg_len=0.05,
                      parent=view.scene, color=color)
 view.camera.set_range()
 
 
-@win.connect
+@canvas.connect
 def on_mouse_move(event):
     if 3 in event.buttons:
-        tr = win.scene.node_transform(vfield)
+        tr = canvas.scene.node_transform(vfield)
         vfield.shared_program['attractor'] = tr.map(event.pos)[:2]
 
 

--- a/examples/demo/scene/force_directed_graph.py
+++ b/examples/demo/scene/force_directed_graph.py
@@ -1,7 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+"""
+Plot clusters of data points and a graph of connections
+"""
 from vispy import app, scene, color
 import numpy as np
-
-# Generate clusters of data points and a graph of connections
 
 # Initialize arrays for position, color, edges, and types for each point in
 # the graph.
@@ -55,8 +59,8 @@ colors = np.clip(colors, 0, 1)
 
 
 # Display the data
-win = scene.SceneCanvas(keys='interactive', show=True, fullscreen=True)
-view = win.central_widget.add_view()
+canvas = scene.SceneCanvas(keys='interactive', show=True)
+view = canvas.central_widget.add_view()
 view.camera = 'panzoom'
 view.camera.aspect = 1
 
@@ -78,6 +82,7 @@ def update(ev):
     dx -= pos[np.newaxis, :, :]
 
     dist = (dx**2).sum(axis=2)**0.5
+    dist[dist == 0] = 1.
     ndx = dx / dist[..., np.newaxis]
     
     force = np.zeros((npts, npts, 2), dtype='float32')

--- a/examples/demo/scene/oscilloscope.py
+++ b/examples/demo/scene/oscilloscope.py
@@ -1,4 +1,13 @@
+# -*- coding: utf-8 -*-
+# vispy: testskip
+# Copyright (c) 2015, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+"""
+Make a realtime oscilloscope
+"""
+
 from __future__ import division
+
 import threading
 import atexit
 import numpy as np

--- a/examples/demo/scene/picking.py
+++ b/examples/demo/scene/picking.py
@@ -20,9 +20,9 @@ selected = None
 # plot data
 cmap = get_colormap('hsl', value=0.5)
 colors = cmap.map(np.linspace(0.1, 0.9, data.shape[0]))
-x = np.arange(data.shape[1]) * (dt * 1000)
+t = np.arange(data.shape[1]) * (dt * 1000)
 for i, y in enumerate(data):
-    line = plt.plot((x, y), color=colors[i])
+    line = plt.plot((t, y), color=colors[i])
     line.interactive = True
     line.data_index = i
 
@@ -76,7 +76,7 @@ def update_cursor(pos):
         pos = tr.map(pos)
         
         # get interpolated y coordinate
-        x = pos[0]
+        x = min(max(pos[0], t[0]), t[-2])
         ind = x / (dt * 1000)
         i = np.floor(ind)
         s = ind - i

--- a/examples/demo/scene/scrolling_plots.py
+++ b/examples/demo/scene/scrolling_plots.py
@@ -1,12 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015, Vispy Development Team.
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+"""
+Show 10,000 realtime scrolling plots
+"""
 from vispy import app, scene
 import numpy as np
 
 
-win = scene.SceneCanvas(keys='interactive', show=True, size=(1024, 768))
-grid = win.central_widget.add_grid()
+canvas = scene.SceneCanvas(keys='interactive', show=True, size=(1024, 768))
+grid = canvas.central_widget.add_grid()
 view = grid.add_view(0, 1)
 view.camera = scene.MagnifyCamera(mag=1, size_factor=0.5, radius_ratio=0.6)
-#view.camera = 'panzoom'
 
 # Add axes
 yax = scene.AxisWidget(orientation='left')

--- a/vispy/app/canvas.py
+++ b/vispy/app/canvas.py
@@ -108,7 +108,7 @@ class Canvas(object):
     time or using a dedicated double-click button will not be respected.
     """
 
-    def __init__(self, title='Vispy canvas', size=(800, 600), position=None,
+    def __init__(self, title='VisPy canvas', size=(800, 600), position=None,
                  show=False, autoswap=True, app=None, create_native=True,
                  vsync=False, resizable=True, decorate=True, fullscreen=False,
                  config=None, shared=None, keys=None, parent=None, dpi=None,

--- a/vispy/gloo/tests/test_glir.py
+++ b/vispy/gloo/tests/test_glir.py
@@ -84,6 +84,7 @@ def test_log_parser():
     i += 1
 
     config.update(glir_file='')
+    glir_file.close()
 
 
 @requires_application()

--- a/vispy/plot/fig.py
+++ b/vispy/plot/fig.py
@@ -17,6 +17,8 @@ class Fig(SceneCanvas):
         Size of the figure window in pixels.
     show : bool
         If True, show the window.
+    **kwargs : dict
+        Keywoard arguments to pass to `SceneCanvas` base class.
 
     Notes
     -----

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -109,7 +109,7 @@ class SceneCanvas(app.Canvas):
     This can cause problems with accessibility, as increasing the OS detection
     time or using a dedicated double-click button will not be respected.
     """
-    def __init__(self, title='Vispy canvas', size=(800, 600), position=None,
+    def __init__(self, title='VisPy canvas', size=(800, 600), position=None,
                  show=False, autoswap=True, app=None, create_native=True,
                  vsync=False, resizable=True, decorate=True, fullscreen=False,
                  config=None, shared=None, keys=None, parent=None, dpi=None,

--- a/vispy/scene/canvas.py
+++ b/vispy/scene/canvas.py
@@ -436,8 +436,8 @@ class SceneCanvas(app.Canvas):
         tr = self.transforms.get_transform('canvas', 'framebuffer')
         pos = tr.map(pos)[:2]
 
-        id = self.render_picking(region=(pos[0]-radius, pos[1]-radius,
-                                         radius * 2 + 1, radius * 2 + 1))
+        id = self._render_picking(region=(pos[0]-radius, pos[1]-radius,
+                                          radius * 2 + 1, radius * 2 + 1))
         ids = []
         seen = set()
         for i in range(radius):

--- a/vispy/scene/tests/test_visuals.py
+++ b/vispy/scene/tests/test_visuals.py
@@ -8,7 +8,7 @@ def test_docstrings():
     for name in dir(visuals):
         obj = getattr(visuals, name)
         if isinstance(obj, type) and issubclass(obj, Node):
-            if obj is Node or VisualNode:
+            if obj is Node or obj is VisualNode:
                 continue
             assert "This class inherits from visuals." in obj.__doc__
             assert "parent : Node" in obj.__doc__

--- a/vispy/scene/visuals.py
+++ b/vispy/scene/visuals.py
@@ -34,7 +34,7 @@ class VisualNode(Node):
         self._id = VisualNode._next_id
         VisualNode._visual_ids[self._id] = self
         VisualNode._next_id += 1
-        self._picking_filter = PickingFilter(id=self._id)
+        self._picking_filter = PickingFilter(id_=self._id)
         self.attach(self._picking_filter)
 
     def _update_opacity(self):

--- a/vispy/visuals/filters/picking.py
+++ b/vispy/visuals/filters/picking.py
@@ -13,7 +13,7 @@ class PickingFilter(object):
     Note that the ID color uses the alpha channel, so this may not be used
     with blending enabled.
     """
-    def __init__(self, id=None):
+    def __init__(self, id_=None):
         self.shader = Function("""
             void picking_filter() {
                 if( $enabled == 0 )
@@ -23,7 +23,7 @@ class PickingFilter(object):
                 gl_FragColor = $id_color;
             }
         """)
-        self.id = id
+        self.id = id_
         self.enabled = False
 
     @property

--- a/vispy/visuals/scrolling_lines.py
+++ b/vispy/visuals/scrolling_lines.py
@@ -143,7 +143,7 @@ class ScrollingLinesVisual(Visual):
         color : array-like
             An array of rgba values.
         """
-        self._color_tex.set_data(c)
+        self._color_tex.set_data(color)
 
     def _prepare_transforms(self, view):
         view.view_program.vert['transform'] = view.get_transform().simplified


### PR DESCRIPTION
After this PR `make pyqt4`, `make nobackend`, `make flake` all pass, and `make examples` has only 8 failures, all of which look like one of these two:

```
----------------------------------------------------------------------
Example basics/scene/volume.py failed (0):
----------------------------------------------------------------------
INFO: Variable u_filter is not an active uniform
INFO: Variable u_id_color is not an active uniform
INFO: Variable u_enabled is not an active uniform

----------------------------------------------------------------------

..............
----------------------------------------------------------------------
Example basics/visuals/mesh.py failed (0):
----------------------------------------------------------------------
INFO: Variable a_v_color is not an active attribute
```

It looks like there is some problem with the `Volume` visual not having the filters attached properly. I'm not sure where the `a_v_color` thing comes from -- @campagnola do you have some idea? Once we have these, I think tests will pass on my system!
